### PR TITLE
 Added metedata dir path to the arg parser and made the required changes

### DIFF
--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -14,7 +14,7 @@ def build_dataset(args):
     dataset_config = DATASET_FUNCTIONS[args.dataset_name][1]()
     
     dataset_dict = {
-        "train": dataset_builder(dataset_config, split_set="train", root_dir=args.dataset_root_dir, augment=True),
+        "train": dataset_builder(dataset_config, split_set="train", root_dir=args.dataset_root_dir, meta_data_dir=args.meta_data_dir, augment=True),
         "test": dataset_builder(dataset_config, split_set="val", root_dir=args.dataset_root_dir, augment=False),
     }
     return dataset_dict, dataset_config

--- a/main.py
+++ b/main.py
@@ -111,6 +111,13 @@ def make_args_parser():
         help="Root directory containing the dataset files. \
               If None, default values from scannet.py/sunrgbd.py are used",
     )
+    parser.add_argument(
+        "--meta_data_dir",
+        type=str,
+        default=None,
+        help="Root directory containing the metadata files. \
+              If None, default values from scannet.py/sunrgbd.py are used",
+    )
     parser.add_argument("--dataset_num_workers", default=4, type=int)
     parser.add_argument("--batchsize_per_gpu", default=8, type=int)
 


### PR DESCRIPTION
I modified two files by adding a few lines to support specifying the path to the scannet metadata directory from the arguments to not manually change the code of scannet.py 