### PR TITLE
Fix issues with training on point colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ third_party/*
 utils/box_intersection.c
 utils/*so
 utils/build/*
+
+# outputs
+outputs/

--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -14,8 +14,21 @@ def build_dataset(args):
     dataset_config = DATASET_FUNCTIONS[args.dataset_name][1]()
     
     dataset_dict = {
-        "train": dataset_builder(dataset_config, split_set="train", root_dir=args.dataset_root_dir, meta_data_dir=args.meta_data_dir, augment=True),
-        "test": dataset_builder(dataset_config, split_set="val", root_dir=args.dataset_root_dir, augment=False),
+        "train": dataset_builder(
+            dataset_config, 
+            split_set="train", 
+            root_dir=args.dataset_root_dir, 
+            meta_data_dir=args.meta_data_dir, 
+            use_color=args.use_color,
+            augment=True
+        ),
+        "test": dataset_builder(
+            dataset_config, 
+            split_set="val", 
+            root_dir=args.dataset_root_dir, 
+            use_color=args.use_color,
+            augment=False
+        ),
     }
     return dataset_dict, dataset_config
     

--- a/datasets/scannet.py
+++ b/datasets/scannet.py
@@ -305,8 +305,8 @@ class ScannetDetectionDataset(Dataset):
             )
 
         raw_sizes = target_bboxes[:, 3:6]
-        point_cloud_dims_min = point_cloud.min(axis=0)
-        point_cloud_dims_max = point_cloud.max(axis=0)
+        point_cloud_dims_min = point_cloud.min(axis=0)[:3]
+        point_cloud_dims_max = point_cloud.max(axis=0)[:3]
 
         box_centers = target_bboxes.astype(np.float32)[:, 0:3]
         box_centers_normalized = shift_scale_points(
@@ -344,7 +344,7 @@ class ScannetDetectionDataset(Dataset):
         ret_dict["gt_angle_residual_label"] = angle_residuals.astype(np.float32)
         target_bboxes_semcls = np.zeros((MAX_NUM_OBJ))
         target_bboxes_semcls[0 : instance_bboxes.shape[0]] = [
-            self.dataset_config.nyu40id2class[x]
+            self.dataset_config.nyu40id2class[int(x)]
             for x in instance_bboxes[:, -1][0 : instance_bboxes.shape[0]]
         ]
         ret_dict["gt_box_sem_cls_label"] = target_bboxes_semcls.astype(np.int64)

--- a/scripts/scannet_masked_ep1080_color.sh
+++ b/scripts/scannet_masked_ep1080_color.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+python main.py \
+--dataset_name scannet \
+--max_epoch 1080 \
+--enc_type masked \
+--enc_dropout 0.3 \
+--nqueries 256 \
+--base_lr 5e-4 \
+--matcher_giou_cost 2 \
+--matcher_cls_cost 1 \
+--matcher_center_cost 0 \
+--matcher_objectness_cost 0 \
+--loss_giou_weight 1 \
+--loss_no_object_weight 0.25 \
+--save_separate_checkpoint_every_epoch -1 \
+--use_color \
+--checkpoint_dir outputs/scannet_masked_ep1080_color


### PR DESCRIPTION
Hi there,

Just noticed this tiny issue that "use_color" option is not included into `datasets.build_dataset()`, albeit provided in the dataset and `main.py`. I've fixed the related issues and added a new training script `scripts/scannet_masked_eq1080_color.sh` for training with point colors. 

I hope this small tweak can be helpful :)

Best
Dave